### PR TITLE
fix columns

### DIFF
--- a/CorsairLED.cs
+++ b/CorsairLED.cs
@@ -36,7 +36,7 @@ namespace MusicBeePlugin
       _about.Type = PluginType.General;
       _about.VersionMajor = 1;  // your plugin version
       _about.VersionMinor = 0;
-      _about.Revision = 0;
+      _about.Revision = 1;
       _about.MinInterfaceVersion = MinInterfaceVersion;
       _about.MinApiRevision = MinApiRevision;
       _about.ReceiveNotifications = (ReceiveNotificationFlags.PlayerEvents | ReceiveNotificationFlags.TagEvents);

--- a/CorsairLED.cs
+++ b/CorsairLED.cs
@@ -260,7 +260,7 @@ namespace MusicBeePlugin
         }
         avg /= jumpwidth;
 
-        if (bar < bardata.Length - 1)
+        if (bar < bardata.Length)
         {
           //bardata[bar] = (float) Math.Sqrt(avg) * 1000f;
           bardata[bar] = (float)Math.Sqrt(avg) * 10f;

--- a/Devices/KeyboardEffectDevice.cs
+++ b/Devices/KeyboardEffectDevice.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using CUE.NET.Brushes;
+using CUE.NET.Devices.Generic;
 using CUE.NET.Devices.Generic.Enums;
 using CUE.NET.Devices.Generic.EventArgs;
 using CUE.NET.Devices.Keyboard;
@@ -148,14 +149,29 @@ namespace MusicBeePlugin.Devices
 
     public int GetDesiredBarCount()
     {
-      // This spans a ledgroup over the number row of the keyboard which is most likely the row with the most keys
-      var rectangleLedGroup = new RectangleLedGroup(Device,
-        new PointF(0f, Device[CorsairKeyboardLedId.D1].LedRectangle.Location.Y),
-        new PointF(Device.DeviceRectangle.Width + 10,
-          Device[CorsairKeyboardLedId.Backspace].LedRectangle.Location.Y * 1.1f), 0.1f, false);
+      // go over each row on the keybaord to determine the max leds in a row
+      CorsairLed[] ledlist =
+      {
+        Device[CorsairLedId.Escape],
+        Device[CorsairLedId.D1],
+        Device[CorsairLedId.Tab],
+        Device[CorsairLedId.CapsLock],
+        Device[CorsairLedId.LeftShift],
+        Device[CorsairLedId.LeftCtrl]
+      };
+      int barcnt = 0;
 
-      return rectangleLedGroup.GetLeds().Count();
+      foreach (var led in ledlist)
+      {
+        var lg = new RectangleLedGroup(Device, new PointF(0f, led.LedRectangle.Location.Y),
+          new PointF(Device.DeviceRectangle.Width + 10, led.LedRectangle.Bottom), 0.1f, false);
+        var cnt = lg.GetLeds().Count();
+        if (cnt > barcnt)
+        {
+          barcnt = cnt;
+        }
+      }
+      return barcnt;
     }
-
   }
 }


### PR DESCRIPTION
fixes #8
- use more generic way to calculate the desired barcount for the Keyboard
- fix off-by-one error in bardata calculation that caused missing data for last columns on keyboard